### PR TITLE
Warn on px usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- Warn when using `px` instead of `rem` or `em`
+
 ## 1.3.3
 
 - Upgrade [stylelint](https://github.com/stylelint/stylelint) which renamed a few ruless

--- a/__tests__/fixtures/invalid.scss
+++ b/__tests__/fixtures/invalid.scss
@@ -11,6 +11,7 @@ h2, h3, h4 {
 }
 .auto {
   color: red;
+  padding: 5px;
 }
 
 .foo {

--- a/__tests__/fixtures/valid.scss
+++ b/__tests__/fixtures/valid.scss
@@ -57,7 +57,7 @@ h1 {
   @extend whatever;
 }
 
-@media (max-width: 300px) {
+@media (max-width: 60rem) {
   body {
     background: red;
   }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -37,7 +37,7 @@ describe('config', () => {
       const { warnings } = results[0];
 
       t.isTrue(errored, "no errors");
-      t.equal(warnings.length, 6, "flags no warnings");
+      t.equal(warnings.length, 8, "flags no warnings");
     });
   });
 });

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ module.exports = {
     "max-nesting-depth": 3,
     "number-leading-zero": null,
     "selector-max-compound-selectors": null,
-    "shorthand-property-no-redundant-values": null
+    "shorthand-property-no-redundant-values": null,
+    "unit-blacklist": ["px", { "severity": "warning" }]
   }
 };


### PR DESCRIPTION
One should use `em` or `rem` instead. `px` breaks accessibility.